### PR TITLE
feat: support pwa

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -577,8 +577,9 @@ module.exports = function(webpackEnv) {
       isEnvProduction &&
         new WorkboxWebpackPlugin.GenerateSW({
           clientsClaim: true,
+          skipWaiting: true,
           exclude: [/\.map$/, /asset-manifest\.json$/],
-          importWorkboxFrom: 'cdn',
+          importWorkboxFrom: 'local',
           navigateFallback: publicUrl + '/index.html',
           navigateFallbackBlacklist: [
             // Exclude URLs starting with /_, as they're likely an API call

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -301,7 +301,7 @@ module.exports = function(webpackEnv) {
               options: {
                 formatter: require.resolve('react-dev-utils/eslintFormatter'),
                 eslintPath: require.resolve('eslint'),
-                
+
               },
               loader: require.resolve('eslint-loader'),
             },
@@ -334,7 +334,7 @@ module.exports = function(webpackEnv) {
                 customize: require.resolve(
                   'babel-preset-react-app/webpack-overrides'
                 ),
-                
+
                 plugins: [
                   [
                     require.resolve('babel-plugin-named-asset-import'),
@@ -373,7 +373,7 @@ module.exports = function(webpackEnv) {
                 ],
                 cacheDirectory: true,
                 cacheCompression: isEnvProduction,
-                
+
                 // If an error happens in a package, it's possible to be
                 // because it was compiled. Thus, we don't want the browser
                 // debugger to show the original code. Instead, the code
@@ -484,7 +484,7 @@ module.exports = function(webpackEnv) {
                 name: 'static/media/[name].[hash:8].[ext]',
               },
             },
-            
+
 
             // ** STOP ** Are you adding a new loader?
             // Make sure to add the new loader(s) before the "file" loader.
@@ -586,6 +586,42 @@ module.exports = function(webpackEnv) {
             // Exclude URLs containing a dot, as they're likely a resource in
             // public/ and not a SPA route
             new RegExp('/[^/]+\\.[^/]+$'),
+          ],
+          runtimeCaching: [
+            // 配置路由请求缓存 对应 workbox.routing.registerRoute
+            {
+              urlPattern: /.*\.js/, // 匹配文件
+              handler: "networkFirst", // 网络优先
+            },
+            {
+              urlPattern: /.*\.css/,
+              handler: "staleWhileRevalidate", // 缓存优先同时后台更新
+              options: {
+                // 这里可以设置 cacheName 和添加插件
+                plugins: [
+                  {
+                    cacheableResponse: {
+                      statuses: [0, 200],
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              urlPattern: /.*\.(png|jpg|jpeg|svg|gif)/,
+              handler: "cacheFirst", // 缓存优先
+              options: {
+                cacheName: 'images',
+                expiration: {
+                  maxAgeSeconds: 24 * 60 * 60, // 最长缓存时间,
+                  maxEntries: 50, // 最大缓存图片数量
+                },
+              },
+            },
+            {
+              urlPattern: /.*\.html/,
+              handler: "networkFirst",
+            },
           ],
         }),
       // TypeScript type checking

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,14 +1,19 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Markdown Nice",
+  "name": "Markdown Nice",
   "icons": [
     {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
+      "src": "https://my-wechat.mdnice.com/mdnice/mdnice%20logo_20191007150129.png",
+      "sizes": "128x128",
+      "type": "image/png"
+    },
+    {
+      "src": "https://my-wechat.mdnice.com/mdnice/mdnice%20logo_20191007150129.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ],
-  "start_url": ".",
+  "start_url": "./index.html",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"

--- a/src/index.js
+++ b/src/index.js
@@ -47,4 +47,4 @@ ReactDOM.render(
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: http://bit.ly/CRA-PWA
-serviceWorker.unregister();
+serviceWorker.register();


### PR DESCRIPTION
开启`PWA`功能。

两个特点：
- 在`mac`的`Chrome`中，支持添加到启动台（桌面）中。
- 离线化

显示的图标和名称在`public/manifest.json`中配置。

## 添加

![image](https://user-images.githubusercontent.com/3783838/66811247-55b16280-ef63-11e9-828a-535d2011f15a.png)

## 启动台

![image](https://user-images.githubusercontent.com/3783838/66811276-64981500-ef63-11e9-837f-fb13dcf7b773.png)


## 打开app效果
![image](https://user-images.githubusercontent.com/3783838/66811307-71b50400-ef63-11e9-8e9f-2937f9d6921e.png)

PS：缓存规则建议检查下看是否符合要求。
`config/webpack.config.js中runtimeCaching`