### PR TITLE
大致改了下，有以下几个点

### DIFF
--- a/src/template/basic.js
+++ b/src/template/basic.js
@@ -23,9 +23,9 @@ blockquote,
 table,
 pre,
 section,
-figure {
-  margin-bottom: 1em;
-  margin-top: 0;
+figure,
+hr {
+  margin: 0 0 1em;
 }
 
 /*段落*/
@@ -164,9 +164,7 @@ del {
 /*分隔线*/
 hr {
   height: 1px;
-  margin: 0;
-  margin-top: .5em;
-  margin-bottom: .5em;
+  marign-top: 1em;
   border: none;
   border-top: 1px solid black;
 }

--- a/src/template/basic.js
+++ b/src/template/basic.js
@@ -25,13 +25,14 @@ pre,
 section,
 figure,
 hr {
-  margin: 0 0 1em;
+  margin: 1em 0;
 }
 
 /*段落*/
 p {
-  font-size: 16px;
-  line-height: 26px;
+  /* font-size: 16px; */
+  /* 26/16 = 1.625 fix: 字体变大不会重叠 */
+  line-height: 1.625;
   color: black;
 }
 
@@ -48,22 +49,26 @@ h6 {
   color: black;
 }
 h1 {
-  font-size: 28px;
+  /* 28/16 = 1.75 */
+  font-size: 1.75em;
 }
 h2 {
-  font-size: 24px;
+  /* 24/16 = 1.5 */
+  font-size: 1.5em;
 }
 h3 {
-  font-size: 20px;
+  /* 20/16 = 1.25 */
+  font-size: 1.25em;
 }
 h4 {
-  font-size: 18px;
+  /* 18/16 = 1.125 */
+  font-size: 1.125em;
 }
 h5 {
-  font-size: 16px;
+  font-size: 1em;
 }
 h6 {
-  font-size: 16px;
+  font-size: 1em;
 }
 
 /*列表*/
@@ -84,9 +89,10 @@ ol {
 }
 
 li section {
+  /* 行高会默认继承 */
+  /* line-height: 26px; */
   margin-top: 5px;
   margin-bottom: 5px;
-  line-height: 26px;
   text-align: left;
   color: rgb(1,1,1); // 只要是纯黑色微信编辑器就会把color这个属性吞掉。。。
   font-weight: 500;
@@ -94,9 +100,9 @@ li section {
 
 /*微信代码样式*/
 .code-snippet__fix .code-snippet__line-index li {
+  /* line-height: 26px; */
   margin-top: 5px;
   margin-bottom: 5px;
-  line-height: 26px;
   text-align: left;
   color: black;
 }
@@ -119,7 +125,7 @@ blockquote {
 blockquote p {
   margin: 0px;
   color: black;
-  line-height: 26px;
+  /* line-height: 26px; */
 }
 
 .table-of-contents a {
@@ -164,7 +170,6 @@ del {
 /*分隔线*/
 hr {
   height: 1px;
-  marign-top: 1em;
   border: none;
   border-top: 1px solid black;
 }
@@ -174,17 +179,19 @@ pre code {
   display: -webkit-box !important;
   font-family: Operator Mono, Consolas, Monaco, Menlo, monospace;
   border-radius: 0px;
-  font-size: 12px;
+  /* 12/16 = 0.75 */
+  font-size: 0.75em;
   padding: 2px;
   -webkit-overflow-scrolling: touch;
 }
 pre code span {
-  line-height: 26px;
+  /* line-height: 26px; */
 }
 
 /*行内代码*/
 p code, li code{
-  font-size: 14px;
+  /* 14/16 = 0.875 */
+  font-size: 0.875em;
   word-wrap: break-word;
   padding: 2px 4px;
   border-radius: 4px;
@@ -231,7 +238,7 @@ table tr:nth-child(2n) {
 
 table tr th,
 table tr td {
-  font-size: 16px;
+  font-size: 1em;
   border: 1px solid #ccc;
   padding: 5px 10px;
   text-align: left;
@@ -245,7 +252,8 @@ table tr th {
 /* 微信代码块 */
 .code-snippet__fix {
   word-wrap: break-word !important;
-  font-size: 14px;
+  /* font-size: 14px; */
+  /* line-height: 20px; */
   display: block;
   color: #333;
   position: relative;
@@ -253,18 +261,14 @@ table tr th {
   border: 1px solid #f0f0f0;
   border-radius: 2px;
   display: flex;
-  line-height: 20px;
 }
 .code-snippet__fix pre {
   margin-bottom: 0px;
   margin-top: 0px;
 }
 .code-snippet__fix .code-snippet__line-index {
+  font-size: 0.75em;
   counter-reset: line;
-  flex-shrink: 0;
-  height: 100%;
-  padding: 1em;
-  list-style-type: none;
   padding: 16px;
   margin: 0;
 }
@@ -276,7 +280,6 @@ table tr th {
 .code-snippet__fix .code-snippet__line-index li::before {
   min-width: 1.5em;
   text-align: right;
-  left: -2.5em;
   counter-increment: line;
   content: counter(line);
   display: inline;
@@ -291,8 +294,8 @@ table tr th {
   -webkit-overflow-scrolling: touch;
 }
 .code-snippet__fix code {
+  /* font-size: 14px; */
   text-align: left;
-  font-size: 14px;
   display: block;
   white-space: pre;
   display: flex;
@@ -342,28 +345,31 @@ table tr th {
 
 .footnote-item {
   display: flex;
+  /* 14/16 = 0.875 */
+  font-size: 0.875em;
 }
 
 .footnote-num {
-  display: inline;
-  width: 10%; /*神奇，50px就不可以*/
+  /* display: inline; */
+  /* width: 10%; 神奇，50px就不可以*/
+  /* 容器是 flex 用 flex 定义 50px 有点宽 */
+  // line-height: 26px;
+  flex: 0 0 auto;
+  margin-right: 10px;
   background: none;
-  font-size: 80%;
   opacity: 0.6;
-  line-height: 26px;
   font-family: ptima-Regular, Optima, PingFangSC-light, PingFangTC-light, 'PingFang SC', Cambria, Cochin, Georgia, Times, 'Times New Roman', serif;
 }
 
 .footnote-item p {
-  display: inline;
-  font-size: 14px;
-  width: 90%;
-  padding: 0px;
+  /* display: inline; */
+  /* width: 90%; */
+  /* line-height: 26px; */
+  /* width: calc(100%-50) */
+  flex: auto;
   margin: 0;
-  line-height: 26px;
   color: black;
   word-break:break-all;
-  width: calc(100%-50)
 }
 
 sub, sup {

--- a/src/template/basic.js
+++ b/src/template/basic.js
@@ -14,12 +14,23 @@ export default `/*默认样式，最佳实践*/
   font-family: Optima-Regular, Optima, PingFangSC-light, PingFangTC-light, 'PingFang SC', Cambria, Cochin, Georgia, Times, 'Times New Roman', serif;
 }
 
+/* 除标题外的块状统一间距 */
+p,
+ul,
+ol,
+dl,
+blockquote,
+table,
+pre,
+section,
+figure {
+  margin-bottom: 1em;
+  margin-top: 0;
+}
+
 /*段落*/
 p {
   font-size: 16px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  margin: 0;
   line-height: 26px;
   color: black;
 }
@@ -58,8 +69,6 @@ h6 {
 /*列表*/
 ul,
 ol {
-  margin-top: 8px;
-  margin-bottom: 8px;
   padding-left: 25px;
   color: black;
 }
@@ -105,8 +114,6 @@ blockquote {
   padding-bottom: 10px;
   padding-left: 20px;
   padding-right: 10px;
-  margin-bottom: 20px;
-  margin-top: 20px;
 }
 
 blockquote p {
@@ -158,17 +165,13 @@ del {
 hr {
   height: 1px;
   margin: 0;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: .5em;
+  margin-bottom: .5em;
   border: none;
   border-top: 1px solid black;
 }
 
 /*代码块*/
-pre {
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
 pre code {
   display: -webkit-box !important;
   font-family: Operator Mono, Consolas, Monaco, Menlo, monospace;
@@ -199,13 +202,6 @@ img {
   display: block;
   margin: 0 auto;
   width: 100%;
-}
-
-/*图片*/
-figure {
-  margin: 0;
-  margin-top: 10px;
-  margin-bottom: 10px;
 }
 
 /*图片描述文字*/
@@ -252,7 +248,6 @@ table tr th {
 .code-snippet__fix {
   word-wrap: break-word !important;
   font-size: 14px;
-  margin: 10px 0;
   display: block;
   color: #333;
   position: relative;
@@ -263,7 +258,7 @@ table tr th {
   line-height: 20px;
 }
 .code-snippet__fix pre {
-  margin-bottom: 10px;
+  margin-bottom: 0px;
   margin-top: 0px;
 }
 .code-snippet__fix .code-snippet__line-index {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7746,11 +7746,6 @@ markdown-it-katex@^2.0.3:
   dependencies:
     katex "^0.6.0"
 
-markdown-it-mathjax@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-mathjax/-/markdown-it-mathjax-2.0.0.tgz#ae2b4f4c5c719a03f9e475c664f7b2685231d9e9"
-  integrity sha1-ritPTFxxmgP55HXGZPeyaFIx2ek=
-
 markdown-it-ruby@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/markdown-it-ruby/-/markdown-it-ruby-0.1.1.tgz#6e2050a9b2c3275afc2844920d53cdffbbe12f78"


### PR DESCRIPTION
1. 使用 margin 控制段落间距，为 1em 涉及标签 p ul ol dl blockquote table pre section figure hr
2. 使用 layout 的字体大小控制全文的字体大小
3. line-height 取消，使用继承即可

问题

1. 复制到微信 table 样式没有了
2. 复制到微信代码块的样式没过去，改了 code-snippet__fix 但没效果