### PR TITLE
[feat] 微信外链转脚注功能优化

### DIFF
--- a/src/utils/editorKeyEvents.js
+++ b/src/utils/editorKeyEvents.js
@@ -40,8 +40,36 @@ const handleWechatOuterLink = (content) => {
   }
 };
 
+const handleReferenceLink = (content) => {
+  const refLinkReg = /[\r\n]+(\s{0,3}?(?:(?:\d+\.|-)\s{0,3}?)?\[(\w+)\]:\s*([^"]+)(?:\s+"(\w+)")?\s*[\r\n]+)+/gi;
+  let res;
+  let newContent = content;
+  // eslint-disable-next-line no-cond-assign
+  while ((res = refLinkReg.exec(content)) !== null) {
+    const lines = res[0].split(/[\r\n]+/).filter((v) => v.trim());
+    // eslint-disable-next-line no-loop-func
+    lines.forEach((refLinkText) => {
+      const lineMatch = refLinkText.match(/\s{0,3}?(?:(?:\d+\.|-)\s{0,3}?)?\[(\w+)\]:\s*([^\s]+)(?:\s+"(\w+)")?/i);
+      if (!lineMatch) {
+        return;
+      }
+      const [rawLine, ref, link, title] = lineMatch;
+      if (/^https?:\/\/mp\.weixin\.qq\.com/i.test(link)) {
+        return;
+      }
+
+      const rawReg = new RegExp("\\[([^\\[\\]\\(\\)]+)\\]\\[" + ref + "\\]", "ig");
+      newContent = newContent
+        .replace(rawReg, (_, name) => `[${name}](${link} "${title || name}")`)
+        .replace(rawLine, "");
+    });
+  }
+  return newContent;
+};
+
 export const parseLinkToFoot = (content, store) => {
   content = handleWechatOuterLink(content);
+  content = handleReferenceLink(content);
   content = content.replace(/([\u4e00-\u9fa5])\$/g, "$1 $");
   content = content.replace(/\$([\u4e00-\u9fa5])/g, "$ $1");
   store.setContent(content);

--- a/src/utils/editorKeyEvents.js
+++ b/src/utils/editorKeyEvents.js
@@ -44,25 +44,25 @@ const handleReferenceLink = (content) => {
   const refLinkReg = /[\r\n]+(\s{0,3}?(?:(?:\d+\.|-)\s{0,3}?)?\[(\w+)\]:\s*([^"]+)(?:\s+"(\w+)")?\s*[\r\n]+)+/gi;
   let res;
   let newContent = content;
+
+  const lineHandler = (refLinkText) => {
+    const lineMatch = refLinkText.match(/\s{0,3}?(?:(?:\d+\.|-)\s{0,3}?)?\[(\w+)\]:\s*([^\s]+)(?:\s+"(\w+)")?/i);
+    if (!lineMatch) {
+      return;
+    }
+    const [rawLine, ref, link, title] = lineMatch;
+    if (/^https?:\/\/mp\.weixin\.qq\.com/i.test(link)) {
+      return;
+    }
+
+    const rawReg = new RegExp("\\[([^\\[\\]\\(\\)]+)\\]\\[" + ref + "\\]", "ig");
+    newContent = newContent.replace(rawReg, (_, name) => `[${name}](${link} "${title || name}")`).replace(rawLine, "");
+  };
+
   // eslint-disable-next-line no-cond-assign
   while ((res = refLinkReg.exec(content)) !== null) {
     const lines = res[0].split(/[\r\n]+/).filter((v) => v.trim());
-    // eslint-disable-next-line no-loop-func
-    lines.forEach((refLinkText) => {
-      const lineMatch = refLinkText.match(/\s{0,3}?(?:(?:\d+\.|-)\s{0,3}?)?\[(\w+)\]:\s*([^\s]+)(?:\s+"(\w+)")?/i);
-      if (!lineMatch) {
-        return;
-      }
-      const [rawLine, ref, link, title] = lineMatch;
-      if (/^https?:\/\/mp\.weixin\.qq\.com/i.test(link)) {
-        return;
-      }
-
-      const rawReg = new RegExp("\\[([^\\[\\]\\(\\)]+)\\]\\[" + ref + "\\]", "ig");
-      newContent = newContent
-        .replace(rawReg, (_, name) => `[${name}](${link} "${title || name}")`)
-        .replace(rawLine, "");
-    });
+    lines.forEach(lineHandler);
   }
   return newContent;
 };


### PR DESCRIPTION
微信外链转脚注功能增加 `[Github][link]` 参考式链接的支持，测试内容

```text
[Github][link]

[link]: https://github.com

```

转换结果

![image](https://user-images.githubusercontent.com/424491/95603337-b4cb8980-0a88-11eb-9709-38387646b3a0.png)

ps. 有一行 eslint 报错必须得那么写，所以加了个 disable 